### PR TITLE
parse html with missing tags (with hope) better

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,24 @@ Get attributes
 ### HTMLElement#rawAttributes
 
 Get escaped (as-it) attributes
+
+### HTMLElement#parentNode
+
+gets parent node
+
+
+### HTMLElement#nodeIndex
+
+the ordinal position of tag in parent elements childern:
+
+### HTMLElement#children
+
+all the tags without text nodes
+
+### HTMLElement#nextSibling
+
+next Sibling tag
+
+### HTMLElement#previousSibling
+
+previous Sibling  tag


### PR DESCRIPTION
added:
+    Object.defineProperty(node, 'parentNode', {value:this,enumerable: false});

added
+    get nextSibling()
+    get previousSibling() 
+    Object.defineProperty(node, 'nodeIndex', {value:this.childNodes.length,enumerable: false});
+    get children()

with hope:
+    made better tag closing rules to be able to parse html with expected errors like unclosed tags.

